### PR TITLE
Passing relative path from tests

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "stdliblist_test.go",
     ],
     data = ["@go_sdk//:files"],
+    rundir = ".",
     deps = ["//go/tools/bazel"],
 )
 

--- a/go/tools/builders/stdliblist_test.go
+++ b/go/tools/builders/stdliblist_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,17 +14,12 @@ func Test_stdliblist(t *testing.T) {
 	testDir := t.TempDir()
 	outJSON := filepath.Join(testDir, "out.json")
 
-	runFilePath, err := bazel.RunfilesPath()
-	if err != nil {
-		t.Errorf("cannot file runfile path %v", err)
-	}
 	test_args := []string{
 		fmt.Sprintf("-out=%s", outJSON),
-		fmt.Sprintf("-sdk=%s", abs(filepath.Join(filepath.Dir(runFilePath), "go_sdk"))),
+		fmt.Sprintf("-sdk=%s", "external/go_sdk"),
 	}
 
-	err = stdliblist(test_args)
-	if err != nil {
+	if err := stdliblist(test_args); err != nil {
 		t.Errorf("calling stdliblist got err: %v", err)
 	}
 	f, err := os.Open(outJSON)


### PR DESCRIPTION
It appears that the test doesn't want us to hard-code "external/go_sdk" in the builder binary, so we have to pass relative paths from tests too. However, it's fine the hard-code "external/go_sdk" in the test. So we can set `rundir = "."` and pass that from tests.

Now you can use `filepath.Rel(".", env.go_sdk)` to get `rel_go_sdk`